### PR TITLE
Deprecation warning on SetNum fix

### DIFF
--- a/Source/ImGui/Private/ImGuiContextProxy.cpp
+++ b/Source/ImGui/Private/ImGuiContextProxy.cpp
@@ -245,7 +245,7 @@ void FImGuiContextProxy::UpdateDrawData(ImDrawData* DrawData)
 {
 	if (DrawData && DrawData->CmdListsCount > 0)
 	{
-		DrawLists.SetNum(DrawData->CmdListsCount, false);
+		DrawLists.SetNum(DrawData->CmdListsCount, EAllowShrinking::No);
 
 		for (int Index = 0; Index < DrawData->CmdListsCount; Index++)
 		{

--- a/Source/ImGui/Private/ImGuiDrawData.cpp
+++ b/Source/ImGui/Private/ImGuiDrawData.cpp
@@ -10,7 +10,7 @@ void FImGuiDrawList::CopyVertexData(TArray<FSlateVertex>& OutVertexBuffer, const
 #endif // ENGINE_COMPATIBILITY_LEGACY_CLIPPING_API
 {
 	// Reset and reserve space in destination buffer.
-	OutVertexBuffer.SetNumUninitialized(ImGuiVertexBuffer.Size, false);
+	OutVertexBuffer.SetNumUninitialized(ImGuiVertexBuffer.Size, EAllowShrinking::No);
 
 	// Transform and copy vertex data.
 	for (int Idx = 0; Idx < ImGuiVertexBuffer.Size; Idx++)
@@ -44,7 +44,7 @@ void FImGuiDrawList::CopyVertexData(TArray<FSlateVertex>& OutVertexBuffer, const
 void FImGuiDrawList::CopyIndexData(TArray<SlateIndex>& OutIndexBuffer, const int32 StartIndex, const int32 NumElements) const
 {
 	// Reset buffer.
-	OutIndexBuffer.SetNumUninitialized(NumElements, false);
+	OutIndexBuffer.SetNumUninitialized(NumElements, EAllowShrinking::No);
 
 	// Copy elements (slow copy because of different sizes of ImDrawIdx and SlateIndex and because SlateIndex can
 	// have different size on different platforms).


### PR DESCRIPTION
Fixing deprecation warning in SetNum and SetNumUninitialized as now it requires EAllowShrinking enum.
Also, thanks for keeping this plugin alive :)