### PR TITLE
Fixed imgui.ini file saving

### DIFF
--- a/Source/ImGui/Private/ImGuiContextProxy.cpp
+++ b/Source/ImGui/Private/ImGuiContextProxy.cpp
@@ -88,7 +88,7 @@ FImGuiContextProxy::FImGuiContextProxy(const FString& InName, int32 InContextInd
 	ImGuiIO& IO = ImGui::GetIO();
 
 	// Manually load data session.
-	IO.IniFilename = NULL;
+	IO.IniFilename = nullptr;
 	ImGui::LoadIniSettingsFromDisk(StringCast<ANSICHAR>(*IniFilename).Get());
 
 	// Start with the default canvas size.

--- a/Source/ImGui/Private/ImGuiContextProxy.cpp
+++ b/Source/ImGui/Private/ImGuiContextProxy.cpp
@@ -87,8 +87,9 @@ FImGuiContextProxy::FImGuiContextProxy(const FString& InName, int32 InContextInd
 	// Start initialization.
 	ImGuiIO& IO = ImGui::GetIO();
 
-	// Set session data storage.
-	IO.IniFilename = StringCast<ANSICHAR>(*IniFilename).Get();
+	// Manually load data session.
+	IO.IniFilename = NULL;
+	ImGui::LoadIniSettingsFromDisk(StringCast<ANSICHAR>(*IniFilename).Get());
 
 	// Start with the default canvas size.
 	ResetDisplaySize();
@@ -115,6 +116,9 @@ FImGuiContextProxy::~FImGuiContextProxy()
 
 		// Ensure frame has ended
 		EndFrame();	
+
+		// Manually save data session.
+		ImGui::SaveIniSettingsToDisk(StringCast<ANSICHAR>(*IniFilename).Get());
 		
 		// Save context data and destroy.
 		ImGui::DestroyContext(Context);


### PR DESCRIPTION
Objects created by StringCasts have very short lifetimes and shouldn't be used as a source of a string after that string goes out of the scope. The Get() gets a pointer, it doesn't perform a copy. 

This lead to a situation where the IO.IniFilename become invalid in the ImGuiContextProxy destructor and the session is not saved.

To solve this issue we can either copy StringCast result using Memcpy function, but this leads us to a dynamic memory management shenanigans, or we can manually save and load a session, which I'm proposing in this pull request.