### PR TITLE
Fix for a possible deadlock

### DIFF
--- a/Source/ImGui/Private/ImGuiInputHandler.cpp
+++ b/Source/ImGui/Private/ImGuiInputHandler.cpp
@@ -159,6 +159,11 @@ FReply UImGuiInputHandler::OnMouseWheel(const FPointerEvent& MouseEvent)
 	return ToReply(true);
 }
 
+void UImGuiInputHandler::ClearMouseDown()
+{
+	InputState->ClearMouseDown();
+}
+
 FReply UImGuiInputHandler::OnMouseMove(const FVector2D& MousePosition, const FPointerEvent& MouseEvent)
 {
 	if (MouseEvent.IsTouchEvent())

--- a/Source/ImGui/Private/ImGuiInputState.cpp
+++ b/Source/ImGui/Private/ImGuiInputState.cpp
@@ -57,6 +57,15 @@ void FImGuiInputState::SetMouseDown(const FKey& MouseButton, bool bIsDown)
 	imguiIO->AddMouseButtonEvent(mouseIndex, bIsDown);	
 }
 
+void FImGuiInputState::ClearMouseDown()
+{
+	const int32 MouseIndexCount = UE_ARRAY_COUNT(imguiIO->MouseDown);
+	for (int32 I = 0; I < MouseIndexCount; I++)
+	{
+		imguiIO->AddMouseButtonEvent(I, false);
+	}
+}
+
 void FImGuiInputState::AddMouseWheelDelta(float DeltaValue)
 {
 	imguiIO->AddMouseWheelEvent(0, DeltaValue);

--- a/Source/ImGui/Private/ImGuiInputState.h
+++ b/Source/ImGui/Private/ImGuiInputState.h
@@ -40,6 +40,11 @@ public:
 	// @param bIsDown - True, if button is down
 	void SetMouseDown(const FKey& MouseButton, bool bIsDown);
 
+	// Utility to release all mouse buttons.
+	// Needed for situations when mouse leaves a viewport
+	// while being in a pressed state.
+	void ClearMouseDown();
+
 	// Get mouse wheel delta accumulated during the last frame.
 	float GetMouseWheelDelta() const { return MouseWheelDelta; }
 

--- a/Source/ImGui/Private/Widgets/SImGuiWidget.cpp
+++ b/Source/ImGui/Private/Widgets/SImGuiWidget.cpp
@@ -435,6 +435,19 @@ void SImGuiWidget::UpdateInputState()
 	auto& Properties = ModuleManager->GetProperties();
 	auto* ContextProxy = ModuleManager->GetContextManager().GetContextProxy(ContextIndex);
 
+	const bool bGameViewportFocusedChanged = (GameViewport->Viewport->HasFocus() != bGameViewportFocused);
+	if (bGameViewportFocusedChanged)
+	{
+		bGameViewportFocused = !bGameViewportFocused;
+		if (bGameViewportFocused)
+		{
+			IMGUI_WIDGET_LOG(Log, TEXT("ImGui Widget %d - Game Viewport refocused. Clearing mouse inputs."),
+				ContextIndex);
+
+			InputHandler->ClearMouseDown();
+		}
+	}
+
 	const bool bEnableTransparentMouseInput = Properties.IsMouseInputShared()
 #if PLATFORM_ANDROID || PLATFORM_IOS
 		&& (FSlateApplication::Get().GetCursorPos() != FVector2D::ZeroVector)

--- a/Source/ImGui/Private/Widgets/SImGuiWidget.h
+++ b/Source/ImGui/Private/Widgets/SImGuiWidget.h
@@ -154,6 +154,7 @@ private:
 	bool bAdaptiveCanvasSize = false;
 	bool bUpdateCanvasSize = false;
 	bool bCanvasControlEnabled = false;
+	bool bGameViewportFocused = true;
 
 	TSharedPtr<SImGuiCanvasControl> CanvasControlWidget;
 	TWeakPtr<SWidget> PreviousUserFocusedWidget;

--- a/Source/ImGui/Public/ImGuiInputHandler.h
+++ b/Source/ImGui/Public/ImGuiInputHandler.h
@@ -82,6 +82,13 @@ public:
 	virtual FReply OnMouseWheel(const FPointerEvent& MouseEvent);
 
 	/**
+	 * Utility to release all mouse buttons.
+	 * Needed for situations when mouse leaves a viewport
+	 * while being in a pressed state.
+	 */
+	virtual void ClearMouseDown();
+
+	/**
 	 * Called to handle mouse move events.
 	 * @param MousePosition Mouse position (in ImGui space)
 	 * @param MouseEvent Optional mouse event passed from Slate


### PR DESCRIPTION
When `bMouseInputShared` is enabled and game is running in PIE there is a chance of ImGUI become unresponsive if we click on the Editor UI and then back on the ImGUI in game viewport. 

The problem is quite annoying, especially that stopping and starting game again doesn't fix it. I had to restart whole editor to get it back to the working state.

This is because, the mouse release event might not be sent to the ImGUI, which leads to the `ImGUI::GetIO().WantCaptureMouse` never being set to true. This is because imGui set's `mouse_avail` to false, because the `io.MouseDown` shows too much pressed mouse buttons... Yeah, I had to do quite a digging to find out what's going on :D  
In the end, because of the incorrect `WantCaptureMouse` the ImGUI widget visibility was never set to `Visible`.

The solution is a little bit brutal, but works. Simply forces mouse buttons release every time a game viewport regain focus.